### PR TITLE
Use lower case header names

### DIFF
--- a/examples/CommNoGui/CSerialPortDemoNoGui.cpp
+++ b/examples/CommNoGui/CSerialPortDemoNoGui.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #define imsleep(microsecond) Sleep(microsecond) // ms
 #else
 #include <unistd.h>

--- a/src/SerialPortInfoWinBase.cpp
+++ b/src/SerialPortInfoWinBase.cpp
@@ -1,6 +1,6 @@
-﻿#include <Windows.h>
+﻿#include <windows.h>
 #include <initguid.h> // GUID
-#include <Setupapi.h> // SetupDiGetClassDevs Setup*
+#include <setupapi.h> // SetupDiGetClassDevs Setup*
 #include <tchar.h>    // _T
 
 #include "CSerialPort/iutils.hpp"

--- a/test/CSerialPortVirtual.cpp
+++ b/test/CSerialPortVirtual.cpp
@@ -2,7 +2,7 @@
 #include "CSerialPort/iutils.hpp"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <tchar.h> //_T
 #else
 #include <errno.h>      // perror

--- a/test/cseiralport_test.cpp
+++ b/test/cseiralport_test.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #define imsleep(microsecond) Sleep(microsecond) // ms
 #else
 #include <unistd.h>


### PR DESCRIPTION
The code currently uses upper case header names in some places (e.g. `Windows.h`). This is an issue when trying to use MINGW which expects them to be lower case. The changes should not affect actual Windows platforms as they are case-insensitive.