### PR TITLE
refactor(CSerialPort): getErrorMsg 移除对 handle 的依赖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 
 # rust
 target
+.xmake

--- a/bindings/c/cserialport.cpp
+++ b/bindings/c/cserialport.cpp
@@ -429,15 +429,9 @@ const char *CSerialPortGetLastErrorMsg(i_handle_t handle)
     return "";
 }
 
-const char *CSerialPortGetErrorMsg(i_handle_t handle, int code)
+const char *CSerialPortErrorToString(int code)
 {
-    itas109::CSerialPort *pCSP = reinterpret_cast<itas109::CSerialPort *>(handle);
-    if (pCSP)
-    {
-        return pCSP->getErrorMsg(code);
-    }
-
-    return "";
+    return itas109::CSerialPort::errorToString(code);
 }
 
 void CSerialPortClearError(i_handle_t handle)

--- a/bindings/c/cserialport.cpp
+++ b/bindings/c/cserialport.cpp
@@ -429,9 +429,9 @@ const char *CSerialPortGetLastErrorMsg(i_handle_t handle)
     return "";
 }
 
-const char *CSerialPortErrorToString(int code)
+const char *CSerialPortErrorToString(enum SerialPortError error)
 {
-    return itas109::CSerialPort::errorToString(code);
+    return itas109::CSerialPort::errorToString(error);
 }
 
 void CSerialPortClearError(i_handle_t handle)

--- a/bindings/c/cserialport.cpp
+++ b/bindings/c/cserialport.cpp
@@ -431,7 +431,7 @@ const char *CSerialPortGetLastErrorMsg(i_handle_t handle)
 
 const char *CSerialPortErrorToString(enum SerialPortError error)
 {
-    return itas109::CSerialPort::errorToString(error);
+    return itas109::toString(static_cast<itas109::SerialPortError>(error));
 }
 
 void CSerialPortClearError(i_handle_t handle)

--- a/bindings/c/cserialport.h
+++ b/bindings/c/cserialport.h
@@ -176,7 +176,7 @@ extern "C"
 
     C_DLL_EXPORT const char *CSerialPortGetLastErrorMsg(i_handle_t handle);
 
-    C_DLL_EXPORT const char *CSerialPortGetErrorMsg(i_handle_t handle, int code);
+    C_DLL_EXPORT const char *CSerialPortErrorToString(int code);
 
     C_DLL_EXPORT void CSerialPortClearError(i_handle_t handle);
 

--- a/bindings/c/cserialport.h
+++ b/bindings/c/cserialport.h
@@ -176,7 +176,7 @@ extern "C"
 
     C_DLL_EXPORT const char *CSerialPortGetLastErrorMsg(i_handle_t handle);
 
-    C_DLL_EXPORT const char *CSerialPortErrorToString(int code);
+    C_DLL_EXPORT const char *CSerialPortErrorToString(enum SerialPortError error);
 
     C_DLL_EXPORT void CSerialPortClearError(i_handle_t handle);
 

--- a/bindings/c/xmake.lua
+++ b/bindings/c/xmake.lua
@@ -8,14 +8,17 @@ target("cserialport")
         add_files("$(projectdir)/lib/version.rc")
     end
     add_includedirs(".", {public = true}) -- cserialport.h
+    add_headerfiles("cserialport.h", {prefixdir = ""})
     add_files("cserialport.cpp")
 
 -- CSerialPort c binding example
-target("CSerialPortDemoC")
-    set_kind("binary")
-    if is_config("CSERIALPORT_ENABLE_NATIVE_SYNC", true) then
-        add_files("example/main_sync_native.c")
-    else
-        add_files("example/main.c")
-    end
-    add_deps("cserialport")
+if is_config("CSERIALPORT_BUILD_EXAMPLES", true) then
+    target("CSerialPortDemoC")
+        set_kind("binary")
+        if is_config("CSERIALPORT_ENABLE_NATIVE_SYNC", true) then
+            add_files("example/main_sync_native.c")
+        else
+            add_files("example/main.c")
+        end
+        add_deps("cserialport")
+end

--- a/bindings/c/xmake.lua
+++ b/bindings/c/xmake.lua
@@ -1,19 +1,13 @@
-add_includedirs(".") -- cserialport.h
+local kind = get_config("kind") or "static"
 
 -- CSerialPort c binding shared library
 target("cserialport")
-    set_kind("shared")
+    set_kind(kind)
     add_defines("CSERIALPORT_BINDING_LANGUAGE=C") -- CSerialPort Binding Language
-    if is_plat("windows") then
+    if is_plat("windows") and kind == "shared" then
         add_files("$(projectdir)/lib/version.rc")
     end
-    
-    add_files("cserialport.cpp")
-
--- CSerialPort c binding static library
-target("cserialport-static")
-    add_defines("CSERIALPORT_BINDING_LANGUAGE=C") -- CSerialPort Binding Language
-    set_kind("static")
+    add_includedirs(".") -- cserialport.h
     add_files("cserialport.cpp")
 
 -- CSerialPort c binding example

--- a/bindings/c/xmake.lua
+++ b/bindings/c/xmake.lua
@@ -7,7 +7,7 @@ target("cserialport")
     if is_plat("windows") and kind == "shared" then
         add_files("$(projectdir)/lib/version.rc")
     end
-    add_includedirs(".") -- cserialport.h
+    add_includedirs(".", {public = true}) -- cserialport.h
     add_files("cserialport.cpp")
 
 -- CSerialPort c binding example

--- a/include/CSerialPort/SerialPort.h
+++ b/include/CSerialPort/SerialPort.h
@@ -287,7 +287,7 @@ public:
      * @param code errorCode 错误码
      * @return return error code message 返回指定错误码信息
      */
-    const char *getErrorMsg(int code) const;
+    static const char *errorToString(int code);
     /**
      * @brief clear error 清除错误信息
      *

--- a/include/CSerialPort/SerialPort.h
+++ b/include/CSerialPort/SerialPort.h
@@ -282,13 +282,6 @@ public:
      */
     const char *getLastErrorMsg() const;
     /**
-     * @brief Get the Error Code Message 获取指定错误码信息
-     *
-     * @param code errorCode 错误码
-     * @return return error code message 返回指定错误码信息
-     */
-    static const char *errorToString(int code);
-    /**
      * @brief clear error 清除错误信息
      *
      */
@@ -413,5 +406,7 @@ private:
     std::unique_ptr<CSerialPortAsyncBase> p_serialPortBase;
 #endif
 };
+
+DLL_EXPORT const char *toString(SerialPortError code);
 } // namespace itas109
 #endif //__CSERIALPORT_H__

--- a/include/CSerialPort/SerialPortBase.h
+++ b/include/CSerialPort/SerialPortBase.h
@@ -213,7 +213,7 @@ public:
      * @param code errorCode 错误码
      * @return return error code message 返回指定错误码信息
      */
-    const char *getErrorMsg(int code) const;
+    static const char *errorToString(int code);
 
     /**
      * @brief clear error 清除错误信息

--- a/include/CSerialPort/SerialPortBase.h
+++ b/include/CSerialPort/SerialPortBase.h
@@ -208,14 +208,6 @@ public:
     const char *getLastErrorMsg() const;
 
     /**
-     * @brief Get the Error Code Message 获取指定错误码信息
-     *
-     * @param code errorCode 错误码
-     * @return return error code message 返回指定错误码信息
-     */
-    static const char *errorToString(int code);
-
-    /**
      * @brief clear error 清除错误信息
      *
      */

--- a/lib/xmake.lua
+++ b/lib/xmake.lua
@@ -1,6 +1,7 @@
 local kind = get_config("kind") or "static"
 target("cserialport")
     set_kind(kind)
+    add_headerfiles("../include/(CSerialPort/*.h)")
     if is_plat("windows") and kind == "shared" then
         add_files("version.rc")
     end

--- a/lib/xmake.lua
+++ b/lib/xmake.lua
@@ -1,10 +1,6 @@
--- cserialport shared library
-target("libcserialport")
-    set_kind("shared")
-    if is_plat("windows") then
+local kind = get_config("kind") or "static"
+target("cserialport")
+    set_kind(kind)
+    if is_plat("windows") and kind == "shared" then
         add_files("version.rc")
     end
-
--- cserialport static library
-target("libcserialport-static")
-    set_kind("static")

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -340,16 +340,9 @@ const char *itas109::CSerialPort::getLastErrorMsg() const
     }
 }
 
-const char *itas109::CSerialPort::getErrorMsg(int code) const
+const char *itas109::CSerialPort::errorToString(int code)
 {
-    if (p_serialPortBase)
-    {
-        return p_serialPortBase->getErrorMsg(code);
-    }
-    else
-    {
-        return "";
-    }
+    return CSerialPortBase::errorToString(code);
 }
 
 void itas109::CSerialPort::clearError()

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -340,11 +340,6 @@ const char *itas109::CSerialPort::getLastErrorMsg() const
     }
 }
 
-const char *itas109::CSerialPort::errorToString(int code)
-{
-    return CSerialPortBase::errorToString(code);
-}
-
 void itas109::CSerialPort::clearError()
 {
     if (p_serialPortBase)
@@ -518,4 +513,54 @@ const char *itas109::CSerialPort::getVersion()
     static char version[256];
     itas109::IUtils::strncpy(version, "https://github.com/itas109/CSerialPort - v", 256);
     return itas109::IUtils::strncat(version, CSERIALPORT_VERSION, 20);
+}
+
+const char *itas109::toString(SerialPortError code)
+{
+    switch (code)
+    {
+        case itas109::ErrorOK:
+            return "success";
+        case itas109::ErrorUnknown:
+            return "unknown error";
+        case itas109::ErrorFail:
+            return "general error";
+        case itas109::ErrorNotImplemented:
+            return "not implemented error";
+        case itas109::ErrorInner:
+            return "innet error";
+        case itas109::ErrorNullPointer:
+            return "null pointer error";
+        case itas109::ErrorInvalidParam:
+            return "invalid param error";
+        case itas109::ErrorAccessDenied:
+            return "access denied error";
+        case itas109::ErrorOutOfMemory:
+            return "out of memory error";
+        case itas109::ErrorTimeout:
+            return "timeout error";
+        case itas109::ErrorNotInit:
+            return "not init error";
+        case itas109::ErrorInitFailed:
+            return "init failed error";
+        case itas109::ErrorAlreadyExist:
+            return "already exist error";
+        case itas109::ErrorNotExist:
+            return "not exist error";
+        case itas109::ErrorAlreadyOpen:
+            return "already open error";
+        case itas109::ErrorNotOpen:
+            return "not open error";
+        case itas109::ErrorOpenFailed:
+            return "open failed error";
+        case itas109::ErrorCloseFailed:
+            return "close failed error";
+        case itas109::ErrorWriteFailed:
+            return "write failed error";
+        case itas109::ErrorReadFailed:
+            return "read failed error";
+        default:
+            return "undefined error code";
+            break;
+    }
 }

--- a/src/SerialPortBase.cpp
+++ b/src/SerialPortBase.cpp
@@ -69,10 +69,10 @@ int CSerialPortBase::getLastError() const
 
 const char *CSerialPortBase::getLastErrorMsg() const
 {
-    return getErrorMsg(m_lastError);
+    return errorToString(m_lastError);
 }
 
-const char *CSerialPortBase::getErrorMsg(int code) const
+const char *CSerialPortBase::errorToString(int code)
 {
     switch (code)
     {

--- a/src/SerialPortBase.cpp
+++ b/src/SerialPortBase.cpp
@@ -1,5 +1,5 @@
 ﻿#include "CSerialPort/SerialPortBase.h"
-
+#include "CSerialPort/SerialPort.h"
 #include "CSerialPort/iutils.hpp"
 
 CSerialPortBase::CSerialPortBase()
@@ -69,57 +69,7 @@ int CSerialPortBase::getLastError() const
 
 const char *CSerialPortBase::getLastErrorMsg() const
 {
-    return errorToString(m_lastError);
-}
-
-const char *CSerialPortBase::errorToString(int code)
-{
-    switch (code)
-    {
-        case itas109::ErrorOK:
-            return "success";
-        case itas109::ErrorUnknown:
-            return "unknown error";
-        case itas109::ErrorFail:
-            return "general error";
-        case itas109::ErrorNotImplemented:
-            return "not implemented error";
-        case itas109::ErrorInner:
-            return "innet error";
-        case itas109::ErrorNullPointer:
-            return "null pointer error";
-        case itas109::ErrorInvalidParam:
-            return "invalid param error";
-        case itas109::ErrorAccessDenied:
-            return "access denied error";
-        case itas109::ErrorOutOfMemory:
-            return "out of memory error";
-        case itas109::ErrorTimeout:
-            return "timeout error";
-        case itas109::ErrorNotInit:
-            return "not init error";
-        case itas109::ErrorInitFailed:
-            return "init failed error";
-        case itas109::ErrorAlreadyExist:
-            return "already exist error";
-        case itas109::ErrorNotExist:
-            return "not exist error";
-        case itas109::ErrorAlreadyOpen:
-            return "already open error";
-        case itas109::ErrorNotOpen:
-            return "not open error";
-        case itas109::ErrorOpenFailed:
-            return "open failed error";
-        case itas109::ErrorCloseFailed:
-            return "close failed error";
-        case itas109::ErrorWriteFailed:
-            return "write failed error";
-        case itas109::ErrorReadFailed:
-            return "read failed error";
-        default:
-            return "undefined error code";
-            break;
-    }
+    return itas109::toString(static_cast<itas109::SerialPortError>(m_lastError));
 }
 
 void CSerialPortBase::clearError()

--- a/xmake.lua
+++ b/xmake.lua
@@ -50,17 +50,16 @@ elseif is_plat("macosx") then
     add_syslinks("Foundation", "IOKit")
 end
 
--- libcserialport
-includes("lib")
-
 -- examples
 if is_config("CSERIALPORT_BUILD_EXAMPLES", true) then
     includes("examples")
 end
 
--- bindings/c
+-- c++ or c
 if is_config("CSERIALPORT_BUILD_BINDING_C", true) then
     includes("bindings/c")
+else
+    includes("lib")
 end
 
 -- test

--- a/xmake.lua
+++ b/xmake.lua
@@ -18,7 +18,7 @@ if is_config("CSERIALPORT_ENABLE_DEBUG", true) then
 end
 
 if is_config("CSERIALPORT_ENABLE_UTF8", true) then
-    add_defines("CSERIALPORT_UTF8") -- CSerialPort UTF8
+    add_defines("CSERIALPORT_USE_UTF8") -- CSerialPort UTF8
 end
 
 -- common include dirs


### PR DESCRIPTION
getErrorMsg 本质上是对 code -> string 的转化，所以用一个静态方法是不是更好，改名为errorToString